### PR TITLE
Add options argument

### DIFF
--- a/lib/node-minify.js
+++ b/lib/node-minify.js
@@ -4,6 +4,7 @@ var minify = function(options) {
 	this.type = options.type;
 	this.fileIn = options.fileIn;
 	this.fileOut = options.fileOut;
+	this.options = options.options || [];
 	if (typeof options.callback !== 'undefined') {
 		this.callback = options.callback;
 	}
@@ -23,13 +24,13 @@ minify.prototype.compress = function() {
 
 	switch (this.type) {
 		case 'yui':
-			command = 'java -jar ' + __dirname + '/yuicompressor-2.4.6.jar ' + this.fileIn + ' -o ' + this.fileOut;
+			command = 'java -jar ' + __dirname + '/yuicompressor-2.4.6.jar ' + this.fileIn + ' -o ' + this.fileOut + ' ' + this.options.join(' ');
 			break;
 		case 'gcc':
-			command = 'java -jar ' + __dirname + '/google_closure_compiler.jar --js=' + this.fileIn + ' --js_output_file=' + this.fileOut;
+			command = 'java -jar ' + __dirname + '/google_closure_compiler.jar --js=' + this.fileIn + ' --js_output_file=' + this.fileOut + ' ' + this.options.join(' ');
 			break;
 		case 'uglifyjs':
-			command = __dirname  + '/../node_modules/uglify-js/bin/uglifyjs --output ' + this.fileOut + ' --no-copyright ' + this.fileIn;
+			command = __dirname  + '/../node_modules/uglify-js/bin/uglifyjs --output ' + this.fileOut + ' --no-copyright ' + this.fileIn + ' ' + this.options.join(' ');
 			break;
 	}
 


### PR DESCRIPTION
This gets useful when you need to pass options to the underlying minifier program, e.g.:

``` javascript
    new compressor.minify({
        type: 'gcc',
        fileIn: input,
        fileOut: output,
        options: [ 
            '--create_source_map', input.replace('.js', '.map'), 
            '--compilation_level', 'ADVANCED_OPTIMIZATIONS'
            ]
    });
```
