### PR TITLE
Fixes YUI compressor crashing in some cases

### DIFF
--- a/lib/node-minify.js
+++ b/lib/node-minify.js
@@ -24,7 +24,7 @@ minify.prototype.compress = function() {
 
 	switch (this.type) {
 		case 'yui':
-			command = 'java -jar ' + __dirname + '/yuicompressor-2.4.7.jar ' + this.fileIn + ' -o ' + this.fileOut + ' ' + this.options.join(' ');
+			command = 'java -jar -Xss2048k' + __dirname + '/yuicompressor-2.4.7.jar ' + this.fileIn + ' -o ' + this.fileOut + ' ' + this.options.join(' ');
 			break;
 		case 'gcc':
 			command = 'java -jar ' + __dirname + '/google_closure_compiler-r1592.jar --js=' + this.fileIn + ' --js_output_file=' + this.fileOut + ' ' + this.options.join(' ');


### PR DESCRIPTION
YUI compressor often crashes with StackOverlowError. The default java stack is 512k, increasing to 2048k fixes this. (http://stackoverflow.com/questions/8831462/yuicompressor-crashes-stackoverflow-error)
