### PR TITLE
disabled temp file for gcc

### DIFF
--- a/lib/node-minify.js
+++ b/lib/node-minify.js
@@ -7,7 +7,7 @@ var minify = (function(undefined) {
 		this.type = options.type;
 		this.tempFile = new Date().getTime().toString();
 		
-		if(options.type != 'gcc' && typeof options.fileIn === 'string') {
+		if(options.type == 'gcc' && typeof options.fileIn === 'string') {
 			this.fileIn = [options.fileIn];
 		}
 		else if(typeof options.fileIn === 'string') {


### PR DESCRIPTION
Sorry for getting on your nerves again :)

Google's Closure Compiler can compress many files at once by writing many --js options. This method is very good in connection with the --create_source_map flag for creating a source map, because I have the line numbers of the right file, not of the temporary file…
