### PR TITLE
Allow using YUI Compressor to compress JavaScript files

### DIFF
--- a/lib/node-minify.js
+++ b/lib/node-minify.js
@@ -50,7 +50,11 @@ var minify = (function(undefined) {
 	
 			switch (this.type) {
 				case 'yui':		
+				case 'yui-css':		
 					command = 'java -jar -Xss2048k "' + __dirname + '/yuicompressor-2.4.7.jar" "' + this.fileIn + '" -o "' + this.fileOut + '" --type css ' + this.options.join(' ');
+					break;
+				case 'yui-js':		
+					command = 'java -jar -Xss2048k "' + __dirname + '/yuicompressor-2.4.7.jar" "' + this.fileIn + '" -o "' + this.fileOut + '" --type js ' + this.options.join(' ');
 					break;
 				case 'gcc':
 					var fileInCommand = this.fileIn.map(function(file) {


### PR DESCRIPTION
Added `yui-js` type and `yui-css` type, which is an alias for the current `yui` type (which defaults to CSS for some reason).

An alternate approach would be to stick to a single `yui` type, and set the compression type to CSS or JS depending on the file extension.

Please publish an updated version on npm after you fix this :)
