### PR TITLE
Adding a new "tempPath" option

### DIFF
--- a/lib/node-minify.js
+++ b/lib/node-minify.js
@@ -5,7 +5,7 @@ var minify = (function(undefined) {
 
 	var minify = function(options) {
 		this.type = options.type;
-		this.tempFile = new Date().getTime().toString();
+		this.tempFile = options.tempPath + new Date().getTime().toString();
 		
 		if(options.type == 'gcc' && typeof options.fileIn === 'string') {
 			this.fileIn = [options.fileIn];


### PR DESCRIPTION
Added tempPath option to allow temporary files to be created in a specified folder rather than just in the root folder.

This is required if you are using nodemon as you will need to include the location that temp files are created in .nodemonignore to prevent continual restarts.
