### PR TITLE
Add copyright option for uglifyjs.

### DIFF
--- a/lib/node-minify.js
+++ b/lib/node-minify.js
@@ -31,6 +31,7 @@ var minify = (function (undefined) {
         this.fileOut = options.fileOut;
         this.options = options.options || [];
         this.buffer = options.buffer || 1000 * 1024;
+        this.copyright = options.copyright || false;
 
         if (typeof options.callback !== 'undefined') {
             this.callback = options.callback;
@@ -43,6 +44,7 @@ var minify = (function (undefined) {
         type: null,
         fileIn: null,
         fileOut: null,
+        copyright: false,
         callback: null,
         buffer: null, // with larger files you will need a bigger buffer for closure compiler
         compress: function () {
@@ -65,7 +67,7 @@ var minify = (function (undefined) {
                     break;
                 case 'uglifyjs':
                     var prefix = (platform === 'win32') ? 'node ' : '';
-                    command = prefix + '"' + __dirname + '/../node_modules/uglify-js/bin/uglifyjs" --output "' + this.fileOut + '" --no-copyright "' + this.fileIn + '" ' + this.options.join(' ');
+                    command = prefix + '"' + __dirname + '/../node_modules/uglify-js/bin/uglifyjs" --output "' + this.fileOut + '" ' + (this.copyright ? '' : '--no-copyright') + ' "' + this.fileIn + '" ' + this.options.join(' ');
                     break;
                 // Useful when wanting only to concatenate the files and not to compress them     
                 case 'no-compress':


### PR DESCRIPTION
There can be someone who don't want to remove copyright.

With this patch, the copyright remains with the option 'copyright' set 'true'.

Thanks.

Regards.
