### PR TITLE
Added publicFolder option

### DIFF
--- a/lib/node-minify.js
+++ b/lib/node-minify.js
@@ -15,8 +15,10 @@ var minify = (function (undefined) {
             this.fileIn = options.fileIn;
         }
 
-        for (var x in options.fileIn) {
-            options.fileIn[x] = options.publicFolder + options.fileIn[x];
+        if (typeof options.publicFolder == 'string') {
+            for (var x in options.fileIn) {
+                options.fileIn[x] = options.publicFolder + options.fileIn[x];
+            }
         }
 
         if (typeof options.fileIn === 'object' && options.fileIn instanceof Array && options.type != 'gcc') {


### PR DESCRIPTION
I wanted to use the same array of javascript files in my view when in development. In order to do so I had to remove public folder from the path. This option allows the option to specify a publicFolder directory to add to the beginning of each file.
