### PR TITLE
Fixed Clousure Compiler link on Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -240,7 +240,7 @@ new compressor.minify({
 
   It will throw an error if you try with CSS files.
 
-  http://code.google.com/closure/compiler
+  https://developers.google.com/closure/compiler/
 
 ## UglifyJS
 


### PR DESCRIPTION
It has been moved from `code.google.com` to `developers.google.com`