### PR TITLE
Fixing location of node_modules - need to go up one more dir.

### DIFF
--- a/lib/node-minify.js
+++ b/lib/node-minify.js
@@ -94,7 +94,7 @@ var minify = (function(undefined) {
       var self = this;
       var command;
       var platform = require('os').platform();
-      var nodeModulesV2 = path.normalize(__dirname + '/../node_modules');
+      var nodeModulesV2 = path.normalize(__dirname + '/../../node_modules');
       var isNPMv2 = dirExistsSync(nodeModulesV2);
       var dirToScan = isNPMv2 ? nodeModulesV2 : '';
       var getPath = function(bin) {


### PR DESCRIPTION
Been getting the following error lately when calling node-minify (from inside another npm). The pull request fixes the error.

Believe this same version of node-minify was not throwing this error on some earlier node / npm combo, but don't remember the detials.

node v5.7.0
npm 3.8.0
node-minify 1.3.7
clean-css 3.4.8

```
Unhandled rejection Error: cleancss not found !
    at getPath (/Users/pajtai/git/desirelist-web-app/node_modules/node-minify/lib/node-minify.js:104:17)
    at Object.minify.fn.compress (/Users/pajtai/git/desirelist-web-app/node_modules/node-minify/lib/node-minify.js:143:27)
    at Object.minify (/Users/pajtai/git/desirelist-web-app/node_modules/node-minify/lib/node-minify.js:83:10)
    at /Users/pajtai/git/desirelist-web-app/node_modules/express-asset-handler/index.js:77:17
```