### PR TITLE
feat(cli): remove all from compressors

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -11,82 +11,15 @@
  */
 
 var chalk = require('chalk');
-var table = require('text-table');
+var deprecate = require('depd')('node-minify');
 var compress = require('./compress');
 var spinner = require('./spinner');
-
-/**
- * Module variables.
- */
-
-var all = ['babel-minify', 'butternut', 'gcc', 'uglifyjs', 'uglify-es', 'yui'];
-var cliOptions;
-var selectedCompressors;
-var processed = 0;
-
-/**
- * Last step after minify.
- */
-
-function finalize(results, smallers) {
-  if (processed === selectedCompressors.length) {
-    var _table = table(results);
-
-    console.log('');
-    console.log(chalk.bgBlue.black(' INFO '), 'Result');
-    console.log('');
-    console.log(_table);
-    console.log('');
-    console.log(chalk.bgBlue.black(' INFO '), formatSmallers(smallers));
-
-    console.log('\nCompressing with ' + chalk.green(smallers[0].compressor) + ' to ' + chalk.yellow(cliOptions.output));
-    runOne(cliOptions, smallers[0].compressor, results, smallers).then(function() {
-      console.log('');
-      console.log(chalk.bgGreen.black(' DONE '), chalk.green('All done!'));
-      console.log('');
-    });
-  }
-}
-
-/**
- * Format the output.
- */
-
-function formatSmallers(smallers) {
-  var sizeGzip = 0;
-  var output = 'The smallest ' + (smallers.length > 1 ? 'are' : 'is') + ': ';
-  smallers.forEach(function(item) {
-    output += chalk.green(item.compressor) + ' ';
-    sizeGzip = chalk.green(item.sizeGzip);
-  });
-  output += 'with ' + sizeGzip;
-  return output;
-}
-
-/**
- * Set the smallers compressor result.
- */
-
-function setSmaller(result, smallers) {
-  if (!smallers[0].sizeGzip) {
-    smallers[0] = result;
-    return;
-  }
-  if (smallers[0].sizeGzip > result.sizeGzip) {
-    smallers = [];
-    smallers[0] = result;
-    return;
-  }
-  if (smallers[0].sizeGzip === result.sizeGzip) {
-    smallers.push(result);
-  }
-}
 
 /**
  * Run one compressor.
  */
 
-function runOne(cli, compressor, results, smallers) {
+function runOne(cli, compressor) {
   return new Promise(function(resolve, reject) {
     var options = {
       compressor: compressor || cli.compressor,
@@ -94,18 +27,15 @@ function runOne(cli, compressor, results, smallers) {
       output: cli.output
     };
 
-    spinner.start(compressor || cli.compressor);
+    spinner.start(options);
 
     return compress(options)
       .then(function(result) {
-        results.push([result.compressor, result.size, result.sizeGzip]);
-        processed++;
-        setSmaller(result, smallers);
-        spinner.stop(compressor);
-        resolve();
+        spinner.stop(result);
+        resolve(result);
       })
       .catch(function(err) {
-        spinner.error(compressor);
+        spinner.error(options);
         reject(err);
       });
   });
@@ -116,52 +46,25 @@ function runOne(cli, compressor, results, smallers) {
  */
 
 function run(cli) {
-  var results = [['Compressor', 'Size minified', 'Size Gzipped']];
-  var smallers = [{ sizeGzip: undefined }];
-  cliOptions = cli;
-
   console.log('');
   console.log(chalk.bgBlue.black(' INFO '), 'Starting compression...');
   console.log('');
 
   return new Promise(function(resolve, reject) {
     if (cli.compressor === 'all') {
-      selectedCompressors = all;
-    } else {
-      selectedCompressors = cli.compressor.split(',');
-      selectedCompressors = selectedCompressors.map(item => item.trim().toLowerCase());
+      deprecate('all is deprecated, babel-minify will be used be default');
+      console.log('');
+      cli.compressor = 'babel-minify';
     }
 
-    const isMultipleCompressors = selectedCompressors.length > 1;
-
-    if (isMultipleCompressors) {
-      var sequence = Promise.resolve();
-      selectedCompressors.forEach(function(compressor) {
-        sequence = sequence
-          .then(function() {
-            return runOne(cli, compressor, results, smallers);
-          })
-          .catch(function() {
-            processed++;
-          });
-      });
-      sequence
-        .then(function() {
-          finalize(results, smallers);
-          resolve();
-        })
-        .catch(reject);
-      return sequence;
-    } else {
-      runOne(cli, cli.compressor, results, smallers)
-        .then(function() {
-          console.log('');
-          console.log(chalk.bgGreen.black(' DONE '), chalk.green('Done!'));
-          console.log('');
-        })
-        .then(resolve)
-        .catch(reject);
-    }
+    runOne(cli, cli.compressor)
+      .then(function() {
+        console.log('');
+        console.log(chalk.bgGreen.black(' DONE '), chalk.green('Done!'));
+        console.log('');
+      })
+      .then(resolve)
+      .catch(reject);
   });
 }
 

--- a/lib/cli/spinner.js
+++ b/lib/cli/spinner.js
@@ -23,17 +23,24 @@ module.exports.error = error;
 
 var spinner = ora();
 
-function start(compressor) {
-  spinner.text = 'Compressing file(s) with ' + chalk.green(compressor) + '...';
+function start(options) {
+  spinner.text = 'Compressing file(s) with ' + chalk.green(options.compressor) + '...';
   spinner.start();
 }
 
-function stop(compressor) {
-  spinner.text = 'File(s) compressed successfully with ' + chalk.green(compressor);
+function stop(result) {
+  spinner.text =
+    'File(s) compressed successfully with ' +
+    chalk.green(result.compressor) +
+    ' (' +
+    chalk.green(result.size) +
+    ' minified, ' +
+    chalk.green(result.sizeGzip) +
+    ' gzipped)';
   spinner.succeed();
 }
 
-function error(compressor) {
-  spinner.text = 'Error - file(s) not compressed with ' + chalk.red(compressor);
+function error(options) {
+  spinner.text = 'Error - file(s) not compressed with ' + chalk.red(options.compressor);
   spinner.fail();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2913,8 +2913,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2935,14 +2934,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2957,20 +2954,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3087,8 +3081,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3100,7 +3093,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3115,7 +3107,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3123,14 +3114,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3149,7 +3138,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3230,8 +3218,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3243,7 +3230,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3329,8 +3315,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3366,7 +3351,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3386,7 +3370,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3430,14 +3413,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7761,7 +7742,8 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "throat": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "node-version": "1.2.0",
     "ora": "3.0.0",
     "sqwish": "0.2.2",
-    "text-table": "0.2.0",
     "uglify-es": "3.3.9",
     "uglify-js": "3.4.6",
     "update-notifier": "2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4733,7 +4733,7 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-text-table@0.2.0, text-table@^0.2.0:
+text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 


### PR DESCRIPTION
The 'all' compressor is:

* too unstable when using big files
* when mixed es5 and es6, some compressors are crashing
* passing options for each compressor is messy