### PR TITLE
fix(uglifyjs): use filename instead of url

### DIFF
--- a/packages/uglify-js/src/uglify-js.js
+++ b/packages/uglify-js/src/uglify-js.js
@@ -25,7 +25,7 @@ const minifyUglifyJS = ({ settings, content, callback, index }) => {
     }
   }
   if (contentMinified.map && settings.options.sourceMap) {
-    utils.writeFile({ file: settings.options.sourceMap.url, content: contentMinified.map, index });
+    utils.writeFile({ file: settings.options.sourceMap.filename, content: contentMinified.map, index });
   }
   utils.writeFile({ file: settings.output, content: contentMinified.code, index });
   if (callback) {


### PR DESCRIPTION
According uglifyjs documentation filename is used as map filename target.
And url is the path of target used in minified file.