### PR TITLE
docs: Fix typo of noCompress example code

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -9,7 +9,7 @@ const minify = require('@node-minify/core');
 const noCompress = require('@node-minify/no-compress');
 
 minify({
-  compressor: 'noCompress',
+  compressor: noCompress,
   input: ['foo.js', 'foo2.js', 'foo3.js'],
   output: 'bar.js',
   callback: function(err, min) {}


### PR DESCRIPTION
Hi,

I happened to find this typo while searching the example code of concatenating files with `node-minify`. 
There are extra single quotes surrounding `noCompress`. 😃 