### PR TITLE
fix(utils): add explicit file extensions to imports and enable eager …

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -112,7 +112,6 @@
       "version": "10.0.0-next.0",
       "dependencies": {
         "@node-minify/utils": "workspace:*",
-        "fast-glob": "^3.3.2",
         "mkdirp": "3.0.1",
       },
       "devDependencies": {
@@ -260,6 +259,7 @@
       "name": "@node-minify/utils",
       "version": "10.0.0-next.0",
       "dependencies": {
+        "fast-glob": "^3.3.3",
         "gzip-size": "7.0.0",
       },
       "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@node-minify/utils": "workspace:*",
-    "fast-glob": "^3.3.2",
     "mkdirp": "3.0.1"
   },
   "devDependencies": {

--- a/packages/utils/__tests__/setPublicFolder.test.ts
+++ b/packages/utils/__tests__/setPublicFolder.test.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { setPublicFolder } from "../src/setPublicFolder.js";
+
+describe("setPublicFolder", () => {
+    test("should return empty object if publicFolder is not a string", () => {
+        // @ts-expect-error testing invalid input
+        const result = setPublicFolder("file.js", null);
+        expect(result).toEqual({});
+    });
+
+    test("should prepend public folder to string input", () => {
+        const result = setPublicFolder("file.js", "public/");
+        expect(result).toEqual({ input: path.normalize("public/file.js") });
+    });
+
+    test("should prepend public folder to array input", () => {
+        const result = setPublicFolder(["file1.js", "file2.js"], "public/");
+        expect(result).toEqual({
+            input: [
+                path.normalize("public/file1.js"),
+                path.normalize("public/file2.js"),
+            ],
+        });
+    });
+
+    test("should not prepend if already present in string input", () => {
+        const result = setPublicFolder("public/file.js", "public/");
+        expect(result).toEqual({ input: path.normalize("public/file.js") });
+    });
+
+    test("should not prepend if already present in array input", () => {
+        const result = setPublicFolder(
+            ["public/file1.js", "file2.js"],
+            "public/"
+        );
+        expect(result).toEqual({
+            input: [
+                path.normalize("public/file1.js"),
+                path.normalize("public/file2.js"),
+            ],
+        });
+    });
+});

--- a/packages/utils/__tests__/wildcards.test.ts
+++ b/packages/utils/__tests__/wildcards.test.ts
@@ -1,0 +1,89 @@
+import fg from "fast-glob";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { wildcards } from "../src/wildcards.js";
+
+// Mock fast-glob globally
+vi.mock("fast-glob", () => {
+    return {
+        default: {
+            globSync: vi.fn(),
+            convertPathToPattern: vi.fn((path) => path),
+        },
+    };
+});
+
+describe("wildcards", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("should return empty object if no wildcards in string input", () => {
+        const result = wildcards("file.js");
+        expect(result).toEqual({});
+    });
+
+    test("should return object with input array if wildcards exist in string input", () => {
+        vi.mocked(fg.globSync).mockReturnValue(["1.js", "2.js"]);
+
+        const result = wildcards("*.js");
+        expect(result).toEqual({ input: ["1.js", "2.js"] });
+    });
+
+    test("should handle array handling without wildcards", () => {
+        const input = ["file1.js", "file2.js"];
+        const result = wildcards(input);
+        expect(result).toEqual({ input: ["file1.js", "file2.js"] });
+    });
+
+    test("should handle array with wildcards", () => {
+        vi.mocked(fg.globSync).mockReturnValue([
+            "expanded1.js",
+            "expanded2.js",
+        ]);
+
+        const input = ["*.js"];
+        const result = wildcards(input);
+        expect(result).toEqual({ input: ["expanded1.js", "expanded2.js"] });
+    });
+
+    test("should handle public folder", () => {
+        vi.mocked(fg.globSync).mockReturnValue(["public/expanded.js"]);
+
+        const result = wildcards("*.js", "public/");
+        expect(result).toEqual({ input: ["public/expanded.js"] });
+    });
+
+    test("should handle windows paths", async () => {
+        const os = await import("node:os");
+        vi.spyOn(os.default, "platform").mockReturnValue("win32");
+        vi.mocked(fg.globSync).mockReturnValue(["win\\expanded.js"]);
+
+        const result = wildcards("*.js", "win\\");
+        expect(result).toEqual({ input: ["win\\expanded.js"] });
+        expect(fg.convertPathToPattern).toHaveBeenCalled();
+    });
+
+    test("should handle array with windows paths", async () => {
+        const os = await import("node:os");
+        vi.spyOn(os.default, "platform").mockReturnValue("win32");
+        vi.mocked(fg.globSync).mockReturnValue(["win\\expanded1.js", "win\\expanded2.js"]);
+
+        const result = wildcards(["*.js"], "win\\");
+        expect(result).toEqual({ input: ["win\\expanded1.js", "win\\expanded2.js"] });
+        expect(fg.convertPathToPattern).toHaveBeenCalled();
+    });
+
+    test("should filter out paths with wildcards if globSync returns them", () => {
+        vi.mocked(fg.globSync).mockReturnValue(["*.js", "file.js"]);
+
+        const result = wildcards("*.js");
+        expect(result).toEqual({ input: ["file.js"] });
+    });
+
+    test("should filter out paths with wildcards in array input", () => {
+        vi.mocked(fg.globSync).mockReturnValue(["*.js", "file.js"]);
+
+        const result = wildcards(["*.js"]);
+        expect(result).toEqual({ input: ["file.js"] });
+    });
+});

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -52,6 +52,7 @@
     "dev": "tsdown src/index.ts --watch"
   },
   "dependencies": {
+    "fast-glob": "^3.3.3",
     "gzip-size": "7.0.0"
   },
   "devDependencies": {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,7 +10,9 @@ import { prettyBytes } from "./prettyBytes.ts";
 import { readFile } from "./readFile.ts";
 import { run } from "./run.ts";
 import { setFileNameMin } from "./setFileNameMin.ts";
+import { setPublicFolder } from "./setPublicFolder.ts";
 import type { BuildArgsOptions } from "./types.ts";
+import { wildcards } from "./wildcards.ts";
 import { writeFile } from "./writeFile.ts";
 
 export {
@@ -26,8 +28,10 @@ export {
     resetDeprecationWarnings,
     run,
     setFileNameMin,
+    setPublicFolder,
     toBuildArgsOptions,
     warnDeprecation,
+    wildcards,
     writeFile,
 };
 

--- a/packages/utils/src/setPublicFolder.ts
+++ b/packages/utils/src/setPublicFolder.ts
@@ -1,0 +1,36 @@
+/*!
+ * node-minify
+ * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * MIT Licensed
+ */
+
+import path from "node:path";
+
+/**
+ * Prepend the public folder to each file.
+ * @param input Path to file(s)
+ * @param publicFolder Path to the public folder
+ */
+export function setPublicFolder(
+    input: string | string[],
+    publicFolder: string
+) {
+    if (typeof publicFolder !== "string") {
+        return {};
+    }
+
+    const normalizedPublicFolder = path.normalize(publicFolder);
+
+    const addPublicFolder = (item: string) => {
+        const normalizedPath = path.normalize(item);
+        return normalizedPath.includes(normalizedPublicFolder)
+            ? normalizedPath
+            : path.normalize(normalizedPublicFolder + item);
+    };
+
+    return {
+        input: Array.isArray(input)
+            ? input.map(addPublicFolder)
+            : addPublicFolder(input),
+    };
+}

--- a/packages/utils/src/wildcards.ts
+++ b/packages/utils/src/wildcards.ts
@@ -1,0 +1,86 @@
+/*!
+ * node-minify
+ * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * MIT Licensed
+ */
+
+import os from "node:os";
+import fg from "fast-glob";
+
+/**
+ * Check if the platform is Windows
+ */
+function isWindows() {
+    return os.platform() === "win32";
+}
+
+/**
+ * Handle wildcards in a path, get the real path of each file.
+ * @param input - Path with wildcards
+ * @param publicFolder - Path to the public folder
+ */
+export function wildcards(input: string | string[], publicFolder?: string) {
+    if (Array.isArray(input)) {
+        return wildcardsArray(input, publicFolder);
+    }
+
+    return wildcardsString(input, publicFolder);
+}
+
+/**
+ * Handle wildcards in a path (string only), get the real path of each file.
+ * @param input - Path with wildcards
+ * @param publicFolder - Path to the public folder
+ */
+function wildcardsString(input: string, publicFolder?: string) {
+    if (!input.includes("*")) {
+        return {};
+    }
+
+    const files = getFilesFromWildcards(input, publicFolder);
+    const finalPaths = files.filter((path: string) => !path.includes("*"));
+
+    return {
+        input: finalPaths,
+    };
+}
+
+/**
+ * Handle wildcards in a path (array only), get the real path of each file.
+ * @param input - Array of paths with wildcards
+ * @param publicFolder - Path to the public folder
+ */
+function wildcardsArray(input: string[], publicFolder?: string) {
+    // Convert input paths to patterns with public folder prefix
+    const inputWithPublicFolder = input.map((item) => {
+        const input2 = publicFolder ? publicFolder + item : item;
+        return isWindows() ? fg.convertPathToPattern(input2) : input2;
+    });
+
+    // Check if any wildcards exist
+    const hasWildcards = inputWithPublicFolder.some((item) =>
+        item.includes("*")
+    );
+
+    // Process paths based on whether wildcards exist
+    const processedPaths = hasWildcards
+        ? fg.globSync(inputWithPublicFolder)
+        : input;
+
+    // Filter out any remaining paths with wildcards
+    const finalPaths = processedPaths.filter(
+        (path: string) => !path.includes("*")
+    );
+
+    return { input: finalPaths };
+}
+
+/**
+ * Get the real path of each file.
+ * @param input - Path with wildcards
+ * @param publicFolder - Path to the public folder
+ */
+function getFilesFromWildcards(input: string, publicFolder?: string) {
+    const fullPath = publicFolder ? `${publicFolder}${input}` : input;
+    return fg.globSync(isWindows() ? fg.convertPathToPattern(fullPath) : fullPath);
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
     format: ["esm"],
-    dts: true,
+    dts: { eager: true },
     clean: true,
     sourcemap: true,
     outExtensions({ format }) {


### PR DESCRIPTION
…dts generation

This fixes build warnings related to missing exports in @node-minify/types and ensures compatibility with node16/nodenext module resolution.

Key improvements:
- Extracts wildcard handling to packages/utils/src/wildcards.ts
- Extracts public folder logic to packages/utils/src/setPublicFolder.ts
- Removes redundant fast-glob dependency from @node-minify/core
- Enables eager dts generation in tsdown.config.ts for better monorepo type resolution