### PR TITLE
chore: update year to 2026

### DIFF
--- a/.plans/minify-html-compressor.md
+++ b/.plans/minify-html-compressor.md
@@ -76,7 +76,7 @@ packages/minify-html/
 ```typescript
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 
@@ -217,7 +217,7 @@ export default defineConfig({
 ```typescript
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/wrangler.toml
+++ b/docs/wrangler.toml
@@ -1,6 +1,6 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "node-minify-docs"
-compatibility_date = "2025-12-27"
+compatibility_date = "2026-01-03"
 pages_build_output_dir = "./dist"
 
 # Automatically place your workloads in an optimal location to minimize latency.

--- a/packages/babel-minify/LICENSE
+++ b/packages/babel-minify/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/babel-minify/__tests__/babel-minify.test.ts
+++ b/packages/babel-minify/__tests__/babel-minify.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/babel-minify/src/index.ts
+++ b/packages/babel-minify/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/__tests__/benchmark.integration.test.ts
+++ b/packages/benchmark/__tests__/benchmark.integration.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/__tests__/benchmark.test.ts
+++ b/packages/benchmark/__tests__/benchmark.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/__tests__/compressor-loader.test.ts
+++ b/packages/benchmark/__tests__/compressor-loader.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/__tests__/metrics.test.ts
+++ b/packages/benchmark/__tests__/metrics.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/__tests__/reporters.test.ts
+++ b/packages/benchmark/__tests__/reporters.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/__tests__/runner-edge-cases.test.ts
+++ b/packages/benchmark/__tests__/runner-edge-cases.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/src/compressor-loader.ts
+++ b/packages/benchmark/src/compressor-loader.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/src/index.ts
+++ b/packages/benchmark/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/src/metrics.ts
+++ b/packages/benchmark/src/metrics.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/src/reporters/console.ts
+++ b/packages/benchmark/src/reporters/console.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/src/reporters/index.ts
+++ b/packages/benchmark/src/reporters/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/src/reporters/json.ts
+++ b/packages/benchmark/src/reporters/json.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/src/reporters/markdown.ts
+++ b/packages/benchmark/src/reporters/markdown.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/src/runner.ts
+++ b/packages/benchmark/src/runner.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/benchmark/src/types.ts
+++ b/packages/benchmark/src/types.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/clean-css/LICENSE
+++ b/packages/clean-css/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/clean-css/__tests__/clean-css.test.ts
+++ b/packages/clean-css/__tests__/clean-css.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/clean-css/src/index.ts
+++ b/packages/clean-css/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/cli/src/bin/cli.ts
+++ b/packages/cli/src/bin/cli.ts
@@ -2,7 +2,7 @@
 
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/cli/src/compress.ts
+++ b/packages/cli/src/compress.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/cli/src/spinner.ts
+++ b/packages/cli/src/spinner.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/core/__tests__/image-integration.test.ts
+++ b/packages/core/__tests__/image-integration.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/core/src/compress.ts
+++ b/packages/core/src/compress.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/crass/LICENSE
+++ b/packages/crass/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/crass/__tests__/crass.test.ts
+++ b/packages/crass/__tests__/crass.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/crass/src/index.ts
+++ b/packages/crass/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/cssnano/LICENSE
+++ b/packages/cssnano/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/cssnano/__tests__/cssnano.test.ts
+++ b/packages/cssnano/__tests__/cssnano.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/cssnano/src/index.ts
+++ b/packages/cssnano/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/csso/LICENSE
+++ b/packages/csso/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/csso/__tests__/csso.test.ts
+++ b/packages/csso/__tests__/csso.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/csso/src/index.ts
+++ b/packages/csso/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/esbuild/LICENSE
+++ b/packages/esbuild/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/esbuild/__tests__/esbuild.test.ts
+++ b/packages/esbuild/__tests__/esbuild.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/google-closure-compiler/LICENSE
+++ b/packages/google-closure-compiler/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/google-closure-compiler/__tests__/google-closure-compiler.test.ts
+++ b/packages/google-closure-compiler/__tests__/google-closure-compiler.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/google-closure-compiler/src/index.ts
+++ b/packages/google-closure-compiler/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/html-minifier/LICENSE
+++ b/packages/html-minifier/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/html-minifier/__tests__/html-minifier.test.ts
+++ b/packages/html-minifier/__tests__/html-minifier.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/html-minifier/src/index.ts
+++ b/packages/html-minifier/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/imagemin/LICENSE
+++ b/packages/imagemin/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/imagemin/__tests__/imagemin.test.ts
+++ b/packages/imagemin/__tests__/imagemin.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/imagemin/src/index.ts
+++ b/packages/imagemin/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/jsonminify/LICENSE
+++ b/packages/jsonminify/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/jsonminify/__tests__/jsonminify.test.ts
+++ b/packages/jsonminify/__tests__/jsonminify.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/jsonminify/src/index.ts
+++ b/packages/jsonminify/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/lightningcss/LICENSE
+++ b/packages/lightningcss/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/lightningcss/__tests__/lightningcss.test.ts
+++ b/packages/lightningcss/__tests__/lightningcss.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/lightningcss/src/index.ts
+++ b/packages/lightningcss/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/minify-html/LICENSE
+++ b/packages/minify-html/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/minify-html/__tests__/minify-html.test.ts
+++ b/packages/minify-html/__tests__/minify-html.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/minify-html/src/index.ts
+++ b/packages/minify-html/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/no-compress/LICENSE
+++ b/packages/no-compress/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/no-compress/__tests__/no-compress.test.ts
+++ b/packages/no-compress/__tests__/no-compress.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/no-compress/src/index.ts
+++ b/packages/no-compress/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/oxc/LICENSE
+++ b/packages/oxc/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/oxc/__tests__/oxc.test.ts
+++ b/packages/oxc/__tests__/oxc.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/oxc/src/index.ts
+++ b/packages/oxc/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/run/LICENSE
+++ b/packages/run/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/run/__tests__/run.test.ts
+++ b/packages/run/__tests__/run.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/sharp/LICENSE
+++ b/packages/sharp/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/sharp/__tests__/sharp.test.ts
+++ b/packages/sharp/__tests__/sharp.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/sharp/src/index.ts
+++ b/packages/sharp/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/sqwish/LICENSE
+++ b/packages/sqwish/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/sqwish/__tests__/sqwish.test.ts
+++ b/packages/sqwish/__tests__/sqwish.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/sqwish/src/index.ts
+++ b/packages/sqwish/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/svgo/LICENSE
+++ b/packages/svgo/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/svgo/__tests__/svgo.test.ts
+++ b/packages/svgo/__tests__/svgo.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/svgo/src/index.ts
+++ b/packages/svgo/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/swc/LICENSE
+++ b/packages/swc/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/swc/__tests__/swc.test.ts
+++ b/packages/swc/__tests__/swc.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/swc/src/index.ts
+++ b/packages/swc/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/terser/LICENSE
+++ b/packages/terser/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/terser/__tests__/terser-error.test.ts
+++ b/packages/terser/__tests__/terser-error.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/terser/__tests__/terser.test.ts
+++ b/packages/terser/__tests__/terser.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/terser/src/index.ts
+++ b/packages/terser/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/types/LICENSE
+++ b/packages/types/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/types/src/types.d.ts
+++ b/packages/types/src/types.d.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/uglify-es/LICENSE
+++ b/packages/uglify-es/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/uglify-es/__tests__/uglify-es.test.ts
+++ b/packages/uglify-es/__tests__/uglify-es.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/uglify-es/src/index.ts
+++ b/packages/uglify-es/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/uglify-js/LICENSE
+++ b/packages/uglify-js/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/uglify-js/__tests__/uglify-js.test.ts
+++ b/packages/uglify-js/__tests__/uglify-js.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/uglify-js/src/index.ts
+++ b/packages/uglify-js/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/LICENSE
+++ b/packages/utils/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/utils/__tests__/compressor-resolver.test.ts
+++ b/packages/utils/__tests__/compressor-resolver.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/__tests__/getContentFromFilesAsync.test.ts
+++ b/packages/utils/__tests__/getContentFromFilesAsync.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/__tests__/isValidFileAsync.test.ts
+++ b/packages/utils/__tests__/isValidFileAsync.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/__tests__/utils.test.ts
+++ b/packages/utils/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/buildArgs.ts
+++ b/packages/utils/src/buildArgs.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/compressSingleFile.ts
+++ b/packages/utils/src/compressSingleFile.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/compressor-resolver.ts
+++ b/packages/utils/src/compressor-resolver.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/deleteFile.ts
+++ b/packages/utils/src/deleteFile.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/deprecation.ts
+++ b/packages/utils/src/deprecation.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/ensureStringContent.ts
+++ b/packages/utils/src/ensureStringContent.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/getContentFromFiles.ts
+++ b/packages/utils/src/getContentFromFiles.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/getFilesizeBrotliInBytes.ts
+++ b/packages/utils/src/getFilesizeBrotliInBytes.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/getFilesizeGzippedInBytes.ts
+++ b/packages/utils/src/getFilesizeGzippedInBytes.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/getFilesizeInBytes.ts
+++ b/packages/utils/src/getFilesizeInBytes.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/isImageFile.ts
+++ b/packages/utils/src/isImageFile.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/isValidFile.ts
+++ b/packages/utils/src/isValidFile.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/prettyBytes.ts
+++ b/packages/utils/src/prettyBytes.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/readFile.ts
+++ b/packages/utils/src/readFile.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/run.ts
+++ b/packages/utils/src/run.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/setFileNameMin.ts
+++ b/packages/utils/src/setFileNameMin.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/setPublicFolder.ts
+++ b/packages/utils/src/setPublicFolder.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/wildcards.ts
+++ b/packages/utils/src/wildcards.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/utils/src/writeFile.ts
+++ b/packages/utils/src/writeFile.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/yui/LICENSE
+++ b/packages/yui/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rodolphe Stoclin
+Copyright (c) 2011-2026 Rodolphe Stoclin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/yui/__tests__/yui.test.ts
+++ b/packages/yui/__tests__/yui.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/packages/yui/src/index.ts
+++ b/packages/yui/src/index.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/tests/integration/cli-benchmark.integration.test.ts
+++ b/tests/integration/cli-benchmark.integration.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/tests/integration/cli-image.integration.test.ts
+++ b/tests/integration/cli-image.integration.test.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -1,6 +1,6 @@
 /*!
  * node-minify
- * Copyright(c) 2011-2025 Rodolphe Stoclin
+ * Copyright (c) 2011-2026 Rodolphe Stoclin
  * MIT Licensed
  */
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "node-minify-docs"
-compatibility_date = "2025-12-27"
+compatibility_date = "2026-01-03"
 pages_build_output_dir = "./docs/dist"
 
 [vars]


### PR DESCRIPTION
## Summary
- Updated copyright headers from `2011-2025` to `2011-2026` in all TypeScript/JavaScript source and test files.
- Updated `LICENSE` files to reflect the year `2026`.
- Updated Cloudflare `compatibility_date` to `2026-01-03` in `wrangler.toml` files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated copyright headers and LICENSE years to 2026 across the repo, and set docs Cloudflare compatibility_date to 2026-01-03. Keeps legal notices current and aligns the docs site with the latest Cloudflare runtime.

<sup>Written for commit 0290a622637c56fa654932eb9134da6e29b81bba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated copyright years to 2026 across project files and license headers.
  * Updated platform compatibility date to 2026-01-03.

* **Documentation**
  * Metadata/header-only updates; no functional, behavioral, API, or test logic modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->