### PR TITLE
chore: run the action on node24, refresh v12 backlog

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,5 +107,5 @@ outputs:
     description: "Full benchmark results as JSON string"
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "packages/action/dist/index.js"

--- a/docs/plans/2026-06-22-v12-backlog.md
+++ b/docs/plans/2026-06-22-v12-backlog.md
@@ -2,20 +2,21 @@
 
 Items deliberately deferred out of the v11 cleanup release (`docs/plans/2026-03-14-v11-plan.md`). None of these block v11. Captured here so the deferrals don't rot into "later means never".
 
-Status as of 2026-06-22 (v11 branch `v11-cleanup`, ready to merge).
+Status as of 2026-09-02: v11.0.0 is published to npm and tagged. Items below are the remaining deferrals, re-checked against the shipped code.
 
 ---
 
-## 1. Finish `node-minify doctor` scanners (v11 spec gap)
+## 1. Add GCC runtime guidance to `node-minify doctor`
 
-**What**: The v11 plan (`docs/plans/2026-03-14-v11-plan.md` lines 70–71) specced two `doctor` detections that were not implemented:
+**Shipped in v11, no longer deferred**: deprecated type-alias detection. `doctor` flags `CompressorReturnType` (→ `CompressorResult`) and `MinifyOptions` (→ `Settings`) in TypeScript imports and re-exports, ignoring comments and template literals. It also gained detection for the removed `@node-minify/run` package and for `engines.node` ranges that still allow Node below 22.
 
-- **Deprecated type-alias usage** — flag source importing/using `CompressorReturnType` (→ `CompressorResult`) or `MinifyOptions` (→ `Settings`).
+**Still outstanding**:
+
 - **Java/GCC runtime guidance** — surface a note when a project uses `google-closure-compiler`, pointing at the runtime caveat (Java may still be invoked upstream) and recommended JS-native alternatives.
 
-**Why deferred**: `doctor` already detects the real migration blockers (removed packages in `package.json`, source imports, workflow YAML) plus legacy-tier warnings. The two missing scanners are migration *nice-to-haves*, not blockers.
+**Why deferred**: `doctor` already detects every v11 breaking change. This is migration polish, not a blocker.
 
-**Where**: `packages/cli/src/doctor.ts` (add two scanners + reporter cases), `packages/cli/__tests__/doctor.test.ts` (clean/dirty cases for each). Registry already carries the GCC `runtime caveat` note via `notes` in `packages/utils/src/compressor-registry.ts`.
+**Where**: `packages/cli/src/doctor.ts` (add one scanner + reporter case), `packages/cli/__tests__/doctor.test.ts` (clean/dirty cases). Note: `CompressorEntry` in `packages/utils/src/compressor-registry.ts` has only `name`, `status`, `packageName` and optional `replacement` — there is **no** `notes` field, so the caveat text needs adding along with the scanner.
 
 **Effort**: Small. Mirrors the existing removed-package scanner pattern.
 
@@ -87,4 +88,14 @@ Status as of 2026-06-22 (v11 branch `v11-cleanup`, ready to merge).
 
 ## Post-release ops (not code — track separately)
 
-- **npm-deprecate the 5 removed packages** on the registry after v11 publishes: `@node-minify/babel-minify`, `@node-minify/uglify-es`, `@node-minify/yui`, `@node-minify/sqwish`, `@node-minify/crass`. Point each deprecation message at its replacement (see registry `replacement` field). v11 assumption deferred this as a post-release concern.
+Status checked against the registry on 2026-09-02, after v11.0.0 published.
+
+- **Done**: the 5 removed compressors are already deprecated on npm — `@node-minify/babel-minify`, `@node-minify/uglify-es`, `@node-minify/yui`, `@node-minify/sqwish`, `@node-minify/crass`. Each message names its replacement.
+- **Outstanding**: `@node-minify/run` is removed in v11 but **not** deprecated on npm, so it still installs silently at `10.5.0`. Deprecate it with:
+
+  ```bash
+  npm deprecate @node-minify/run "@node-minify/run was removed in v11. It was an internal Java/process-spawn helper with no public replacement; remove it from your dependencies."
+  ```
+
+- **Release tagging**: `GITHUB_TOKEN` cannot create a tag whose tree adds `.github/workflows/*`, so the major tag (`v11`) had to be pushed manually. Every future major hits this. Fix with a fine-grained PAT (contents + workflows write) stored as a secret, or by excluding workflow files from the tagged tree.
+- **Publish failures are silent**: `scripts/publish.ts` catches every `npm publish` error as "may already exist" and still exits 0, so a real failure is indistinguishable from a no-op. Verify published versions against the registry rather than trusting a green Publish run.

--- a/docs/plans/2026-06-22-v12-backlog.md
+++ b/docs/plans/2026-06-22-v12-backlog.md
@@ -98,4 +98,4 @@ Status checked against the registry on 2026-09-02, after v11.0.0 published.
   ```
 
 - **Release tagging**: `GITHUB_TOKEN` cannot create a tag whose tree adds `.github/workflows/*`, so the major tag (`v11`) had to be pushed manually. Every future major hits this. Fix with a fine-grained PAT (contents + workflows write) stored as a secret, or by excluding workflow files from the tagged tree.
-- **Publish failures are silent**: `scripts/publish.ts` catches every `npm publish` error as "may already exist" and still exits 0, so a real failure is indistinguishable from a no-op. Verify published versions against the registry rather than trusting a green Publish run.
+- **Publish failures are non-fatal**: `scripts/publish.ts` logs `npm publish` and `changeset tag` errors as "may already exist" but still exits 0, so CI cannot distinguish a real failure from a no-op. Until that is fixed, verify published versions against the registry rather than trusting a green Publish run.

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -107,5 +107,5 @@ outputs:
     description: "Full benchmark results as JSON string"
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Post-v11 cleanup

Small follow-ups found by checking the shipped state against the repo. No user-facing behavior change.

### Action runs on `node24`

Both manifests declared `using: "node20"`. GitHub already force-migrates node20 actions and warns on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24

The bundle targets node22+, so `node24` is pinned explicitly in `action.yml` and `packages/action/action.yml`. Verified against the docs that `node24` is a supported `runs.using` value, and smoke-tested the built bundle end-to-end on a modern runtime:

```
exit: 0
✅ Minification complete! 31.3% reduction in 9ms
var g=function(n){return"hi "+n};
```

The composite action at `.github/actions/node-minify/action.yml` is `using: composite` and unaffected.

### v12 backlog corrected

It had drifted from the code it describes:

- **Item 1** listed deprecated type-alias detection as outstanding, but **v11 shipped it** — along with `@node-minify/run` and `engines.node` scanners. Only the GCC runtime guidance remains.
- It stated the compressor registry carries the GCC caveat via a `notes` field. `CompressorEntry` has only `name`, `status`, `packageName` and optional `replacement` — **there is no `notes` field**, so a v12 implementer would have gone looking for something that doesn't exist.
- **Post-release ops** listed all 5 removed compressors as pending npm deprecation. Checked the registry: all 5 are already deprecated with replacement messages. Only `@node-minify/run` is still undeprecated.

Also recorded the two release traps this cycle exposed, so they aren't rediscovered at v12:

- `GITHUB_TOKEN` cannot create a tag whose tree adds `.github/workflows/*`, so the major tag needed a manual push
- `scripts/publish.ts` catches every `npm publish` error as "may already exist" and exits 0 — a real failure is indistinguishable from a no-op

### Verification

| Gate | Result |
| :--- | :--- |
| build | pass |
| lint / typecheck | pass |
| test | **1047 passed** (70 files) |
| removed-compressor guard | pass |
| action manifests parse, `using=node24` | pass |
| action bundle minifies end-to-end | pass |

### Needs your npm credentials

`@node-minify/run` was removed in v11 but still installs silently at `10.5.0`. I'm not authenticated to npm locally, so this one is yours:

```bash
npm deprecate @node-minify/run "@node-minify/run was removed in v11. It was an internal Java/process-spawn helper with no public replacement; remove it from your dependencies."
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the GitHub action to `node24` in both manifests and corrects the v12 backlog doc to match what v11 actually shipped.

- GitHub force-migrates node20 actions to node24 with warnings on every run; the bundle already targets node22+, so this removes the warnings.
- The backlog wrongly listed deprecated type-alias detection as outstanding (v11 shipped it), claimed a `notes` field that doesn't exist on `CompressorEntry`, and listed all 5 removed compressors as pending deprecation when only `@node-minify/run` remains.
- Records two release traps for v12: `GITHUB_TOKEN` can't create a tag that adds workflow files, and `scripts/publish.ts` logs publish failures but exits 0, so CI can't distinguish a real failure from a no-op.

`@node-minify/run` still installs silently at `10.5.0`; deprecating it requires npm credentials.

<sup>Written for commit 353c98513964cc5a78273752ed5c0e841718c780. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srod/node-minify/pull/2907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Upgraded the GitHub Action runtime from Node.js 20 to Node.js 24.
* **Documentation**
  * Updated the v12 backlog to reflect completed v11 work and current release-operation items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->